### PR TITLE
Dont write Debug output to syslog

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -52,9 +52,11 @@ void asmlog(int level, const char* format, ...)
 	}
 
 	va_start(ap, format);
+	
 	if (level >= LOG_ERR) {
-	vsyslog(level, format, ap);
+		vsyslog(level, format, ap);
 	}
+	
 	if (level <= loglevel) {
 		fprintf(os,"asmdll: ");
 		vfprintf(os, format, ap);

--- a/src/util.c
+++ b/src/util.c
@@ -52,7 +52,9 @@ void asmlog(int level, const char* format, ...)
 	}
 
 	va_start(ap, format);
+	if (level >= LOG_ERR) {
 	vsyslog(level, format, ap);
+	}
 	if (level <= loglevel) {
 		fprintf(os,"asmdll: ");
 		vfprintf(os, format, ap);


### PR DESCRIPTION
Only prints Error or higher to syslog.
I dont know why all debug log has to land in syslog...
